### PR TITLE
Add AI chat widget and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md — mmccormick.github.io
+
+## Project Overview
+
+Matt McCormick's personal portfolio site. Jekyll static site with a Neumorphism dark theme, hosted on GitHub Pages at **mattcmccormick.com**.
+
+Stack: Jekyll 3.9, SCSS, vanilla JS, Gulp build pipeline, Cloudflare Worker (AI chat).
+
+---
+
+## Branch & Deployment Workflow
+
+```
+feature/branch  →  PR into main  →  PR main into production  →  live at mattcmccormick.com
+```
+
+- **`production`** — deploys to GitHub Pages (mattcmccormick.com). Never commit directly.
+- **`main`** — integration branch. PRs go here first for review.
+- **`assistant`** — current WIP branch for the AI chat widget feature.
+- Feature branches should be short-lived and named descriptively (e.g. `update-resume`, `fix-timeline-layout`).
+
+### Git Rules
+
+- Never push directly to `production` or `main`.
+- Always work on a feature branch, then open a PR into `main`.
+- When ready to deploy: PR `main` → `production`.
+- Write concise, descriptive commit messages (imperative mood: "Add chat widget" not "Added chat widget").
+- Do not force-push to shared branches.
+
+---
+
+## Development
+
+```bash
+# Install dependencies (first time or after gem changes)
+bundle install
+npm install
+
+# Start local dev server at http://localhost:4000
+npm run dev
+
+# Production build
+npm run prod
+```
+
+The Gulp pipeline compiles SCSS → `assets/css/main.min.css`, concatenates JS → `assets/js/app.min.js`, and runs Jekyll with incremental builds + BrowserSync.
+
+Note: `_config_dev.yml` overrides are applied locally. It disables `show_os_projects` to avoid needing a GitHub API token in development.
+
+---
+
+## Key Files & Structure
+
+```
+_config.yml              # Site settings, section toggles, chat_worker_url
+_config_dev.yml          # Local dev overrides (not deployed)
+_data/
+  resume.json            # Full resume: experience, education, projects, interests
+  projects.yml           # Portfolio projects shown in Projects section
+  timeline.yml           # Career timeline entries
+  about_content.yml      # About Me section body text
+  skills-languages.yml   # Language skills with weights
+  skills-frameworks.yml  # Framework skills with weights
+  skills-tools.yml       # Tool skills with weights
+_layouts/
+  default.html           # Main page layout (all sections + chat widget)
+_includes/
+  chat-widget.html       # AI chat widget (self-contained: HTML + CSS + JS)
+  section-*.html         # Individual page section components
+_sass/main.scss          # All custom styles
+_js/app.js               # Main JS (particles, typing effect, AOS, skills)
+worker/
+  index.js               # Cloudflare Worker — AI chat backend
+  wrangler.toml          # Worker deployment config
+```
+
+---
+
+## AI Chat Widget
+
+The chat widget (`_includes/chat-widget.html`) is a floating panel that calls a Cloudflare Worker, which proxies to the Anthropic API (Claude Haiku) with a system prompt containing Matt's full bio and resume data.
+
+**To enable:** Set `chat_worker_url` in `_config.yml` to the deployed worker URL.
+**Widget renders only if `chat_worker_url` is set** — blank disables it silently.
+
+### Cloudflare Worker
+
+```bash
+cd worker
+npx wrangler deploy                       # deploy
+npx wrangler secret put ANTHROPIC_API_KEY # set API key (one-time)
+```
+
+The worker URL and ANTHROPIC_API_KEY are the only secrets. The key is stored as a Cloudflare Worker secret and never exposed to the client.
+
+If you update Matt's data (resume, projects, etc.), update the system prompt in `worker/index.js` and redeploy the worker.
+
+---
+
+## Design System
+
+Dark Neumorphism theme:
+- Background: `rgba(43, 45, 47, 1)` (#2b2d2f)
+- Primary accent: `#07c0ff` (cyan)
+- Text: `#fff`
+- Font: Raleway (body), Josefin Sans (numbers)
+- Cards use `box-shadow` for neumorphic depth, `border-radius: 2rem`
+- Skill colors: languages `#4a7bd9`, frameworks `#07c0ff`, tools `#7ad9c2`
+
+---
+
+## Content Updates
+
+All content is data-driven — edit the files in `_data/` rather than HTML:
+- Resume/experience → `_data/resume.json`
+- Projects section → `_data/projects.yml`
+- Timeline → `_data/timeline.yml`
+- About text → `_data/about_content.yml`
+- Skills → `_data/skills-languages.yml`, `skills-frameworks.yml`, `skills-tools.yml`
+- Site title, social links, section toggles → `_config.yml`
+
+After updating `_data/resume.json` or other data files, also update the system prompt in `worker/index.js` so the AI assistant stays in sync.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.17.3-x64-mingw-ucrt)
-    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (228)
@@ -254,7 +253,6 @@ GEM
     unf_ext (0.0.9.1)
     unf_ext (0.0.9.1-x64-mingw-ucrt)
     unicode-display_width (1.8.0)
-    wdm (0.2.0)
     webrick (1.9.1)
 
 PLATFORMS
@@ -267,7 +265,6 @@ DEPENDENCIES
   jekyll
   jekyll-data
   jekyll-github-metadata
-  wdm (>= 0.1.0)
   webrick
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -121,6 +121,12 @@ google_analytics: G-JQ232L7CYC
 
 contact_email: contact@mattcmccormick.com
 
+# AI CHAT WIDGET
+# Set this to your Cloudflare Worker URL after deployment.
+# Leave blank to disable the chat widget.
+# chat_worker_url: https://matt-portfolio-chat.YOUR_SUBDOMAIN.workers.dev
+chat_worker_url: https://matt-portfolio-chat.mattcmccormick.workers.dev
+
 # Build settings
 plugins:
   - jekyll-feed

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,1 +1,2 @@
 baseurl: "" # the subpath of your site, e.g. /blog
+show_os_projects: false

--- a/_includes/chat-widget.html
+++ b/_includes/chat-widget.html
@@ -195,6 +195,9 @@
   #chat-send:hover { transform: scale(1.08); }
   #chat-send:disabled { opacity: 0.4; cursor: default; transform: none; }
   #chat-send svg { width: 1rem; height: 1rem; fill: #fff; }
+  .chat-msg ul { margin: 0.25rem 0 0; padding-left: 1.1rem; }
+  .chat-msg li { margin-bottom: 0.2rem; }
+  .chat-msg strong { color: #fff; font-weight: 600; }
 </style>
 
 <button id="chat-fab" aria-label="Chat with Matt's AI assistant" title="Ask me about Matt">
@@ -255,10 +258,34 @@
     }
   }
 
+  function renderMarkdown(text) {
+    // Escape HTML first
+    var escaped = text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    // Bold
+    escaped = escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    // Bullet lists: collect consecutive "- item" lines into <ul>
+    escaped = escaped.replace(/((?:^|\n)- .+)+/g, function(block) {
+      var items = block.trim().split('\n').map(function(line) {
+        return '<li>' + line.replace(/^- /, '') + '</li>';
+      }).join('');
+      return '<ul>' + items + '</ul>';
+    });
+    // Line breaks (outside of block elements)
+    escaped = escaped.replace(/\n/g, '<br>');
+    // Clean up <br> inside <ul>
+    escaped = escaped.replace(/<br>(<\/?[uo]l>|<li>)/g, '$1');
+    escaped = escaped.replace(/(<\/li>)<br>/g, '$1');
+    return escaped;
+  }
+
   function appendMessage(role, text) {
     var div = document.createElement('div');
     div.className = 'chat-msg ' + role;
-    div.textContent = text;
+    if (role === 'assistant') {
+      div.innerHTML = renderMarkdown(text);
+    } else {
+      div.textContent = text;
+    }
     messagesEl.appendChild(div);
     messagesEl.scrollTop = messagesEl.scrollHeight;
     return div;

--- a/_includes/chat-widget.html
+++ b/_includes/chat-widget.html
@@ -1,0 +1,346 @@
+{% if site.chat_worker_url %}
+<style>
+  #chat-fab {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    background: linear-gradient(145deg, rgba(100,100,105,0.2) 15%, rgba(20,20,20,0.6) 80%);
+    box-shadow: -4px -3px 6px 0 rgba(250,250,250,0.1), 4px 4px 6px 0 rgba(0,0,0,0.5);
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9000;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+  #chat-fab:hover {
+    transform: scale(1.08);
+    box-shadow: -5px -4px 8px 0 rgba(250,250,250,0.13), 5px 5px 8px 0 rgba(0,0,0,0.6);
+  }
+  #chat-fab svg {
+    width: 1.6rem;
+    height: 1.6rem;
+    fill: #07c0ff;
+    transition: fill 0.2s;
+  }
+  #chat-fab.open svg {
+    fill: #fff;
+  }
+
+  #chat-panel {
+    position: fixed;
+    bottom: 5.5rem;
+    right: 1.5rem;
+    width: 340px;
+    max-width: calc(100vw - 3rem);
+    height: 480px;
+    max-height: calc(100vh - 7rem);
+    background: rgba(43, 45, 47, 0.97);
+    border-radius: 1.5rem;
+    box-shadow: 5px 5px 20px rgba(0,0,0,0.7), -3px -3px 10px rgba(70,70,70,0.15);
+    display: flex;
+    flex-direction: column;
+    z-index: 8999;
+    overflow: hidden;
+    font-family: "Raleway", sans-serif;
+    color: #fff;
+    transform: translateY(1rem) scale(0.97);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+  #chat-panel.open {
+    opacity: 1;
+    pointer-events: all;
+    transform: translateY(0) scale(1);
+  }
+
+  #chat-header {
+    padding: 1rem 1.25rem 0.75rem;
+    border-bottom: 1px solid rgba(255,255,255,0.07);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+  }
+  #chat-header-icon {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #07c0ff 0%, #0090c0 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  #chat-header-icon svg {
+    width: 1rem;
+    height: 1rem;
+    fill: #fff;
+  }
+  #chat-header-text {
+    flex: 1;
+  }
+  #chat-header-text strong {
+    display: block;
+    font-size: 0.9rem;
+    color: #07c0ff;
+    letter-spacing: 0.02em;
+  }
+  #chat-header-text span {
+    font-size: 0.7rem;
+    color: rgba(255,255,255,0.5);
+  }
+  #chat-close {
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.4);
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+    padding: 0.25rem;
+    transition: color 0.2s;
+  }
+  #chat-close:hover { color: #fff; }
+
+  #chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(7,192,255,0.3) transparent;
+  }
+  #chat-messages::-webkit-scrollbar { width: 4px; }
+  #chat-messages::-webkit-scrollbar-thumb { background: rgba(7,192,255,0.3); border-radius: 2px; }
+
+  .chat-msg {
+    max-width: 88%;
+    padding: 0.6rem 0.9rem;
+    border-radius: 1rem;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    word-break: break-word;
+  }
+  .chat-msg.user {
+    align-self: flex-end;
+    background: linear-gradient(135deg, #07c0ff 0%, #0090c0 100%);
+    color: #fff;
+    border-bottom-right-radius: 0.25rem;
+  }
+  .chat-msg.assistant {
+    align-self: flex-start;
+    background: rgba(255,255,255,0.07);
+    color: rgba(255,255,255,0.9);
+    border-bottom-left-radius: 0.25rem;
+  }
+  .chat-msg.typing {
+    align-self: flex-start;
+    background: rgba(255,255,255,0.07);
+    color: rgba(255,255,255,0.5);
+    font-style: italic;
+  }
+  .chat-msg.error {
+    align-self: flex-start;
+    background: rgba(220,50,50,0.15);
+    color: rgba(255,120,120,0.9);
+    border-bottom-left-radius: 0.25rem;
+  }
+
+  #chat-input-area {
+    padding: 0.75rem 1rem;
+    border-top: 1px solid rgba(255,255,255,0.07);
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+  #chat-input {
+    flex: 1;
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(7,192,255,0.2);
+    border-radius: 0.75rem;
+    color: #fff;
+    font-family: "Raleway", sans-serif;
+    font-size: 0.82rem;
+    padding: 0.55rem 0.85rem;
+    outline: none;
+    resize: none;
+    transition: border-color 0.2s;
+    line-height: 1.4;
+  }
+  #chat-input:focus {
+    border-color: rgba(7,192,255,0.5);
+  }
+  #chat-input::placeholder { color: rgba(255,255,255,0.3); }
+  #chat-send {
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #07c0ff 0%, #0090c0 100%);
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    align-self: flex-end;
+    transition: opacity 0.2s, transform 0.15s;
+  }
+  #chat-send:hover { transform: scale(1.08); }
+  #chat-send:disabled { opacity: 0.4; cursor: default; transform: none; }
+  #chat-send svg { width: 1rem; height: 1rem; fill: #fff; }
+</style>
+
+<button id="chat-fab" aria-label="Chat with Matt's AI assistant" title="Ask me about Matt">
+  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2C6.48 2 2 6.48 2 12c0 1.85.5 3.58 1.37 5.07L2 22l4.93-1.37C8.42 21.5 10.15 22 12 22c5.52 0 10-4.48 10-10S17.52 2 12 2zm0 18c-1.66 0-3.2-.46-4.53-1.26l-.32-.19-3.31.92.92-3.31-.19-.32C3.46 15.2 3 13.66 3 12 3 7.03 7.03 3 12 3s9 4.03 9 9-4.03 9-9 9zm4.5-6.75c-.25-.12-1.47-.72-1.7-.81-.23-.08-.39-.12-.56.12-.17.25-.64.81-.78.97-.14.17-.29.19-.54.06-.25-.12-1.05-.39-2-1.23-.74-.66-1.24-1.47-1.38-1.72-.14-.25-.02-.38.11-.51.11-.11.25-.29.37-.43.13-.14.17-.25.25-.41.08-.17.04-.31-.02-.43-.06-.12-.56-1.34-.76-1.84-.2-.48-.41-.42-.56-.43h-.48c-.17 0-.43.06-.66.31-.22.25-.86.85-.86 2.07 0 1.22.89 2.4 1.01 2.56.12.17 1.75 2.67 4.23 3.74.59.26 1.05.41 1.41.52.59.19 1.13.16 1.56.1.47-.07 1.47-.6 1.67-1.18.21-.58.21-1.07.14-1.18-.06-.1-.23-.16-.48-.28z"/>
+  </svg>
+</button>
+
+<div id="chat-panel" role="dialog" aria-label="Chat with Matt's AI assistant" aria-hidden="true">
+  <div id="chat-header">
+    <div id="chat-header-icon">
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
+      </svg>
+    </div>
+    <div id="chat-header-text">
+      <strong>Matt's AI Assistant</strong>
+      <span>Ask me anything about Matt</span>
+    </div>
+    <button id="chat-close" aria-label="Close chat">&#x2715;</button>
+  </div>
+  <div id="chat-messages" aria-live="polite" aria-relevant="additions"></div>
+  <div id="chat-input-area">
+    <textarea id="chat-input" placeholder="Ask about Matt's experience, skills..." rows="1" aria-label="Your message"></textarea>
+    <button id="chat-send" aria-label="Send message" disabled>
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+      </svg>
+    </button>
+  </div>
+</div>
+
+<script>
+(function() {
+  var WORKER_URL = '{{ site.chat_worker_url }}';
+  var fab = document.getElementById('chat-fab');
+  var panel = document.getElementById('chat-panel');
+  var closeBtn = document.getElementById('chat-close');
+  var messagesEl = document.getElementById('chat-messages');
+  var input = document.getElementById('chat-input');
+  var sendBtn = document.getElementById('chat-send');
+  var history = [];
+  var isOpen = false;
+  var isLoading = false;
+  var hasGreeted = false;
+
+  function togglePanel() {
+    isOpen = !isOpen;
+    fab.classList.toggle('open', isOpen);
+    panel.classList.toggle('open', isOpen);
+    panel.setAttribute('aria-hidden', String(!isOpen));
+    if (isOpen) {
+      if (!hasGreeted) {
+        hasGreeted = true;
+        appendMessage('assistant', "Hi! I'm Matt's AI assistant. Ask me anything about his experience, skills, or projects — I'm happy to help!");
+      }
+      input.focus();
+    }
+  }
+
+  function appendMessage(role, text) {
+    var div = document.createElement('div');
+    div.className = 'chat-msg ' + role;
+    div.textContent = text;
+    messagesEl.appendChild(div);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    return div;
+  }
+
+  function setLoading(loading) {
+    isLoading = loading;
+    sendBtn.disabled = loading || input.value.trim().length === 0;
+    input.disabled = loading;
+  }
+
+  function autoResize() {
+    input.style.height = 'auto';
+    input.style.height = Math.min(input.scrollHeight, 80) + 'px';
+  }
+
+  async function sendMessage() {
+    var text = input.value.trim();
+    if (!text || isLoading) return;
+
+    appendMessage('user', text);
+    history.push({ role: 'user', content: text });
+    input.value = '';
+    input.style.height = 'auto';
+    sendBtn.disabled = true;
+    setLoading(true);
+
+    var typingEl = appendMessage('typing', 'Thinking\u2026');
+
+    try {
+      var res = await fetch(WORKER_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, history: history.slice(0, -1) }),
+      });
+      var data = await res.json();
+      typingEl.remove();
+
+      if (data.error) {
+        appendMessage('error', data.error);
+      } else {
+        appendMessage('assistant', data.response);
+        history.push({ role: 'assistant', content: data.response });
+        // Keep history bounded
+        if (history.length > 40) history = history.slice(-40);
+      }
+    } catch (err) {
+      typingEl.remove();
+      appendMessage('error', 'Could not reach the AI service. Please try again.');
+    }
+
+    setLoading(false);
+  }
+
+  fab.addEventListener('click', togglePanel);
+  closeBtn.addEventListener('click', togglePanel);
+
+  input.addEventListener('input', function() {
+    autoResize();
+    sendBtn.disabled = isLoading || input.value.trim().length === 0;
+  });
+
+  input.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+
+  sendBtn.addEventListener('click', sendMessage);
+
+  // Close on Escape
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && isOpen) togglePanel();
+  });
+
+  // Close on outside click
+  document.addEventListener('click', function(e) {
+    if (isOpen && !panel.contains(e.target) && !fab.contains(e.target)) {
+      togglePanel();
+    }
+  });
+})();
+</script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,5 +63,6 @@
     {% endif %}
   </div>
   {% include footer.html %}
+  {% include chat-widget.html %}
 </body>
 </html> 

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,208 @@
+const ALLOWED_ORIGINS = [
+  'https://mmccormick.github.io',
+  'https://mattcmccormick.com',
+  'http://localhost:4000',
+  'http://127.0.0.1:4000',
+];
+
+const SYSTEM_PROMPT = `You are an AI assistant on Matt McCormick's personal portfolio website. Answer questions about Matt in a friendly, concise, and professional manner. Speak in third person (e.g., "Matt has..." not "I have..."). Keep responses under 200 words unless a detailed answer is clearly needed. If asked something not covered here, say you don't have that info and suggest contacting Matt at contact@mattcmccormick.com. If asked about availability for work, note that Matt is currently open to new opportunities.
+
+---
+
+## About Matt
+
+**Name:** Matt McCormick
+**Title:** Senior Full-Stack Engineer | Web Applications & AI
+**Email:** contact@mattcmccormick.com
+**LinkedIn:** linkedin.com/in/mattcmccormick
+**GitHub:** github.com/mmccormick
+
+**Summary:**
+Senior full-stack engineer with over a decade of experience building web applications. Recent deep work in AI and LLM integration — extraction pipelines, interactive agent systems, and AI-powered document processing. Strong across TypeScript, Python, Ruby, PostgreSQL, and modern AI tooling.
+
+**Bio (as shown on site):**
+Matt has well over a decade of experience creating production-grade software. He's worked on a wide range of projects, from at-scale messaging systems to AI-powered document processing and LLM integration. Most recently he built extraction pipelines and interactive AI workflows for a government contracting platform. He excels at learning new systems and developing creative solutions, with a strong foundation in TypeScript, Ruby on Rails, Python, and modern AI tooling.
+
+---
+
+## Work Experience
+
+**Full-Stack AI Engineer — GovSignals** (April 2025 – February 2026, Remote)
+- Built an end-to-end requirements extraction pipeline for government solicitations using LLMs, with document hierarchy preservation and source traceability.
+- Migrated AI content generation from background jobs to an interactive tool-call architecture with real-time user feedback.
+- Designed schemas for document management, requirements tracking, and versioning.
+- Debugged complex AI agent issues including LLM tool-call loops and distributed system failures using session replay and observability tooling.
+- Built data ingestion pipelines for 10+ years of government awards and spending records.
+- Stack: TypeScript, SvelteKit, PostgreSQL, LLM Integration
+
+**Independent Game Developer / AI Engineer — Choice Rolls** (January 2023 – March 2025, New York, NY)
+- Developed a fully interactive, text-based adventure game with AI-driven mechanics (currently in private beta).
+- Explored cutting-edge AI technologies including OpenAI, vector databases, and embedding methods.
+- Implemented semantic memory using plaintext, JSON, and vectors for emergent storytelling.
+- Stack: Python, OpenAI, LangChain, Vector Databases
+
+**Acting CTO — One Click Politics** (June 2020 – January 2021, New York, NY)
+- Led hiring during COVID-19, overseeing a seamless back-end team transition.
+- Became primary point of contact for critical technical matters, restoring board confidence in technical leadership.
+- Managed a team of back-end developers and coordinated with the front-end team.
+
+**Senior Back-End Software Engineer — One Click Politics** (February 2018 – June 2020, New York, NY)
+- Developed major features including Video Messaging and Legislator Search.
+- Integrated three APIs for CRM metadata synchronization.
+- Maintained the existing RabbitMQ messaging system (200,000+ requests per day).
+
+**Full Stack Web Consultant — Self-Employed** (January 2014 – February 2018, Los Angeles, CA)
+- Worked with many companies on a contract basis: NinjaThat, FolioHD, Philosophie LLC, Laurel & Wolf, Betterific, and others.
+
+**CTO / Web Developer — Swink.tv** (June 2013 – January 2014, Los Angeles, CA)
+- Revamped user-facing front end of Swink.tv (browser-based youth sports video platform).
+- Rebuilt a simplified product from the ground up; created a Rails API consumed by an Ember.js front end.
+- Swink was later acquired by CoachNow.
+
+**Co-Founder — Spruceling** (September 2012 – February 2013, Philadelphia, PA)
+- Technical co-founder at DreamIt Startup Accelerator.
+- Built a children's clothing donation matching platform with full-stack Rails, PostgreSQL, and Stamps.com API integration.
+
+**Junior Software Engineer — Tech Limelight** (June 2010 – August 2012, Boston, MA)
+- Developed front end (HTML, CSS, JavaScript, jQuery) and back end (Ruby on Rails, PostgreSQL) for a product showcase platform.
+
+---
+
+## Education
+
+- **B.A. in Computer Science & Music** — Tufts University, Medford, MA (GPA: 3.75, May 2010)
+- **Semester Abroad** — University of Limerick, Ireland (Spring 2009)
+- **High School Diploma** — Mohawk Trail Regional High School, Buckland, MA (May 2006)
+
+---
+
+## Skills
+
+**Languages:** Python (expert), Ruby (expert), TypeScript (expert), JavaScript (proficient), SQL (proficient)
+
+**Frameworks & Libraries:** Ruby on Rails (expert), RESTful APIs (expert), OpenAI SDK (expert), AI Agents (proficient), Vercel AI SDK (proficient), SvelteKit (proficient), Flask (proficient), Node.js (proficient), LangChain (proficient), React (proficient)
+
+**Tools & Platforms:** PostgreSQL (expert), Cursor (expert), Git (proficient), AWS (proficient), Claude Code (proficient), Supabase (proficient), Vector Databases (proficient), CI/CD (proficient), Trigger.dev (proficient), Linear (proficient), Docker (familiar)
+
+---
+
+## Notable Projects
+
+**AI Document Processing Pipeline** — Built an end-to-end pipeline for parsing unstructured government solicitations, extracting and classifying requirements using LLMs, with deep strategy integration and content generation. (GovSignals, govsignals.ai)
+
+**Choice Rolls** — Fully interactive, AI-driven text-based adventure game. Implemented semantic memory using vectors and embeddings for emergent storytelling. Private beta. (choicerolls.com)
+
+**Legislative Databases** — Built a 'Legislator Search' feature from public datasets for One Click Politics. Contributed to the open-source unitedstates/congress-legislators project. Completed in under a month.
+
+**Video Messaging** — Designed and implemented a video messaging feature for One Click Politics, significantly increasing user engagement.
+
+**CRM Metadata Synchronization** — Integrated three APIs to enable 2-way contact syncing for One Click Politics customers.
+
+**Swink.tv UI & API Redesign** — Redesigned the front end and built a Rails API; platform was later acquired by CoachNow.
+
+**Spruceling (DreamIt 2012)** — Co-developed a children's clothing donation matching site at DreamIt Startup Accelerator.
+
+---
+
+## Outside Interests
+
+Improvisation, Interactive Storytelling, Procedural Generation, Emergent Narrative, Game Design, Singing, Performance
+
+---
+
+## Contact
+
+Email: contact@mattcmccormick.com
+LinkedIn: https://www.linkedin.com/in/mattcmccormick
+GitHub: https://github.com/mmccormick
+`;
+
+function getCorsHeaders(origin) {
+  const allowed = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    'Access-Control-Allow-Origin': allowed,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+  };
+}
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get('Origin') || '';
+    const corsHeaders = getCorsHeaders(origin);
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405, headers: corsHeaders });
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { message, history = [] } = body;
+
+    if (!message || typeof message !== 'string' || message.trim().length === 0) {
+      return new Response(JSON.stringify({ error: 'Message is required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (message.length > 1000) {
+      return new Response(JSON.stringify({ error: 'Message too long' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Build messages array (keep last 10 exchanges max for context)
+    const recentHistory = history.slice(-20);
+    const messages = [
+      ...recentHistory.map(h => ({ role: h.role, content: h.content })),
+      { role: 'user', content: message.trim() },
+    ];
+
+    const anthropicResponse = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 512,
+        system: SYSTEM_PROMPT,
+        messages,
+      }),
+    });
+
+    if (!anthropicResponse.ok) {
+      const err = await anthropicResponse.text();
+      console.error('Anthropic API error:', err);
+      return new Response(JSON.stringify({ error: 'AI service unavailable. Please try again.' }), {
+        status: 502,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const data = await anthropicResponse.json();
+    const responseText = data.content?.[0]?.text ?? 'Sorry, I could not generate a response.';
+
+    return new Response(JSON.stringify({ response: responseText }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "matt-portfolio-chat"
+main = "index.js"
+compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat"]
+
+# Deploy with:
+#   cd worker
+#   npx wrangler deploy
+#
+# Set your API key secret (one time):
+#   npx wrangler secret put ANTHROPIC_API_KEY


### PR DESCRIPTION
## Summary
- Adds a floating AI chat widget powered by a Cloudflare Worker + Claude Haiku
- Widget is self-contained in `_includes/chat-widget.html` (HTML, CSS, JS)
- Cloudflare Worker in `worker/` proxies to Anthropic API with Matt's full bio/resume as system prompt
- Widget enabled via `chat_worker_url` in `_config.yml`; blank disables it
- Adds `CLAUDE.md` with project context, branch workflow, and key file map
- Fixes local dev GitHub API error via `show_os_projects: false` in `_config_dev.yml`

## Test plan
- [ ] Chat button appears bottom-right on the live site
- [ ] Panel opens/closes correctly
- [ ] AI responses render with markdown (bold, bullets)
- [ ] Widget is absent if `chat_worker_url` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)